### PR TITLE
fix: ignores files with `permalink=false`

### DIFF
--- a/packages/eleventy-plugin-images-responsiver/.eleventy.js
+++ b/packages/eleventy-plugin-images-responsiver/.eleventy.js
@@ -4,10 +4,10 @@ const imagesResponsiver = require('images-responsiver');
 let imagesResponsiverOptions;
 
 const imagesResponsiverTransform = (content, outputPath) => {
-  if (!outputPath.endsWith('.html')) {
-    return content;
+  if (outputPath && outputPath.endsWith('.html')) {
+    return imagesResponsiver(content, imagesResponsiverOptions);
   }
-  return imagesResponsiver(content, imagesResponsiverOptions);
+  return content;
 };
 
 module.exports = {


### PR DESCRIPTION
When using `permalink=false` in front matter, the `outputPath` is `undefined`.